### PR TITLE
Directly use `edit_settings` command

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -15,6 +15,10 @@
     },
     {
         "caption": "Preferences: Atomic Soft Tab Nav Settings",
-        "command": "atomic_soft_tab_nav_edit_settings"
+        "command": "edit_settings",
+        "args": {
+            "base_file": "${packages}/Atomic Soft Tab Nav/Atomic Soft Tab Nav.sublime-settings",
+            "default":  "// See the left pane for the list of settings and valid values\n{\n\t\"enable_line_nav\": ${0:false}\n}\n"
+        }
     }
 ]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -14,8 +14,12 @@
                         "children":
                         [
                             {
-                                "command": "atomic_soft_tab_nav_edit_settings",
-                                "caption": "Settings"
+                                "caption": "Settings",
+                                "command": "edit_settings",
+                                "args": {
+                                    "base_file": "${packages}/Atomic Soft Tab Nav/Atomic Soft Tab Nav.sublime-settings",
+                                    "default":  "// See the left pane for the list of settings and valid values\n{\n\t\"enable_line_nav\": ${0:false}\n}\n"
+                                }
                             }
                         ]
                     }

--- a/atomic_soft_tab_nav.py
+++ b/atomic_soft_tab_nav.py
@@ -129,20 +129,6 @@ class SoftTabNavListener(sublime_plugin.EventListener):
 
 
 # Window Commands of Preferences
-class AtomicSoftTabNavEditSettingsCommand(sublime_plugin.WindowCommand):
-    def run(self):
-        self.window.run_command(
-            'edit_settings',
-            {
-                "base_file": "${packages}/Atomic Soft Tab Nav/Atomic Soft Tab Nav.sublime-settings",
-                "default":
-                    "// See the left pane for the list of settings and valid values\n"
-                    "{\n"
-                    '    "enable_line_nav": false$0\n'
-                    "}\n"
-            }
-        )
-
 
 class AtomicSoftTabNavSetLineNavSettingsCommand(sublime_plugin.WindowCommand):
     def run(self, **args):


### PR DESCRIPTION
Wrapping `edit_settings` just to provide default content is probably of little value.

This PR therefore proposes to follow common scheme of most other plugins to use `edit_settings` directly in main menu and command palette.